### PR TITLE
[DB構築] 検索基盤テーブル(categories, rephrases, search_logs)の作成と関連付け

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,6 @@
 inherit_from: .rubocop_todo.yml
 
-require:
+plugins:
   - rubocop-rails
   - rubocop-rspec
 

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,5 +1,5 @@
 class Category < ApplicationRecord
-  has_many :rephrases
+  has_many :rephrases, dependent: :destroy
 
   validates :name, presence: true, uniqueness: true
 end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,3 +1,4 @@
+# Category is a phrase grouping used to classify rephrases.
 class Category < ApplicationRecord
   has_many :rephrases, dependent: :destroy
 

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,0 +1,5 @@
+class Category < ApplicationRecord
+  has_many :rephrases
+
+  validates :name, presence: true, uniqueness: true
+end

--- a/app/models/rephrase.rb
+++ b/app/models/rephrase.rb
@@ -1,6 +1,7 @@
 class Rephrase < ApplicationRecord
   belongs_to :category
-  has_many :search_logs
+  has_many :search_logs, dependent: :destroy
 
+  validates :category, presence: true
   validates :content, presence: true
 end

--- a/app/models/rephrase.rb
+++ b/app/models/rephrase.rb
@@ -1,0 +1,6 @@
+class Rephrase < ApplicationRecord
+  belongs_to :category
+  has_many :search_logs
+
+  validates :content, presence: true
+end

--- a/app/models/rephrase.rb
+++ b/app/models/rephrase.rb
@@ -1,7 +1,7 @@
+# Rephrase stores a rewritten phrase and belongs to one category.
 class Rephrase < ApplicationRecord
   belongs_to :category
   has_many :search_logs, dependent: :destroy
 
-  validates :category, presence: true
   validates :content, presence: true
 end

--- a/app/models/search_log.rb
+++ b/app/models/search_log.rb
@@ -1,5 +1,6 @@
 class SearchLog < ApplicationRecord
   belongs_to :rephrase
 
+  validates :rephrase, presence: true
   validates :query, presence: true
 end

--- a/app/models/search_log.rb
+++ b/app/models/search_log.rb
@@ -1,0 +1,5 @@
+class SearchLog < ApplicationRecord
+  belongs_to :rephrase
+
+  validates :query, presence: true
+end

--- a/app/models/search_log.rb
+++ b/app/models/search_log.rb
@@ -1,6 +1,6 @@
+# SearchLog records a search query and its selected rephrase.
 class SearchLog < ApplicationRecord
   belongs_to :rephrase
 
-  validates :rephrase, presence: true
   validates :query, presence: true
 end

--- a/db/migrate/20260220130425_create_categories.rb
+++ b/db/migrate/20260220130425_create_categories.rb
@@ -1,0 +1,11 @@
+class CreateCategories < ActiveRecord::Migration[7.2]
+  def change
+    create_table :categories do |t|
+      t.string :name, null: false
+
+      t.timestamps
+    end
+
+    add_index :categories, :name, unique: true
+  end
+end

--- a/db/migrate/20260220130425_create_categories.rb
+++ b/db/migrate/20260220130425_create_categories.rb
@@ -1,3 +1,4 @@
+# Creates categories used to group rephrases.
 class CreateCategories < ActiveRecord::Migration[7.2]
   def change
     create_table :categories do |t|

--- a/db/migrate/20260220130426_create_rephrases.rb
+++ b/db/migrate/20260220130426_create_rephrases.rb
@@ -1,0 +1,10 @@
+class CreateRephrases < ActiveRecord::Migration[7.2]
+  def change
+    create_table :rephrases do |t|
+      t.text :content, null: false
+      t.references :category, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20260220130426_create_rephrases.rb
+++ b/db/migrate/20260220130426_create_rephrases.rb
@@ -1,3 +1,4 @@
+# Creates rephrases linked to categories.
 class CreateRephrases < ActiveRecord::Migration[7.2]
   def change
     create_table :rephrases do |t|

--- a/db/migrate/20260220130427_create_search_logs.rb
+++ b/db/migrate/20260220130427_create_search_logs.rb
@@ -1,0 +1,10 @@
+class CreateSearchLogs < ActiveRecord::Migration[7.2]
+  def change
+    create_table :search_logs do |t|
+      t.string :query, null: false
+      t.references :rephrase, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20260220130427_create_search_logs.rb
+++ b/db/migrate/20260220130427_create_search_logs.rb
@@ -1,3 +1,4 @@
+# Creates search logs linked to rephrases.
 class CreateSearchLogs < ActiveRecord::Migration[7.2]
   def change
     create_table :search_logs do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,42 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema[7.2].define(version: 2026_02_20_130427) do
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
+  create_table "categories", force: :cascade do |t|
+    t.string "name", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["name"], name: "index_categories_on_name", unique: true
+  end
+
+  create_table "rephrases", force: :cascade do |t|
+    t.text "content", null: false
+    t.bigint "category_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["category_id"], name: "index_rephrases_on_category_id"
+  end
+
+  create_table "search_logs", force: :cascade do |t|
+    t.string "query", null: false
+    t.bigint "rephrase_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["rephrase_id"], name: "index_search_logs_on_rephrase_id"
+  end
+
+  add_foreign_key "rephrases", "categories"
+  add_foreign_key "search_logs", "rephrases"
+end

--- a/spec/factories/categories.rb
+++ b/spec/factories/categories.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :category do
+    sequence(:name) { |n| "category_#{n}" }
+  end
+end

--- a/spec/factories/rephrases.rb
+++ b/spec/factories/rephrases.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :rephrase do
+    content { "言い換えテキスト" }
+    association :category
+  end
+end

--- a/spec/factories/search_logs.rb
+++ b/spec/factories/search_logs.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :search_log do
+    query { "検索キーワード" }
+    association :rephrase
+  end
+end

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -27,4 +27,13 @@ RSpec.describe Category, type: :model do
       expect(duplicate.errors[:name]).to include('has already been taken')
     end
   end
+
+  describe 'dependent destroy' do
+    it 'deletes associated rephrases when category is destroyed' do
+      category = FactoryBot.create(:category)
+      FactoryBot.create(:rephrase, category: category)
+
+      expect { category.destroy }.to change(Rephrase, :count).by(-1)
+    end
+  end
 end

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+RSpec.describe Category, type: :model do
+  describe 'associations' do
+    it 'has many rephrases' do
+      association = described_class.reflect_on_association(:rephrases)
+      expect(association.macro).to eq(:has_many)
+    end
+  end
+
+  describe 'validations' do
+    it 'is valid with a name' do
+      expect(FactoryBot.build(:category)).to be_valid
+    end
+
+    it 'is invalid without a name' do
+      category = FactoryBot.build(:category, name: nil)
+      expect(category).not_to be_valid
+      expect(category.errors[:name]).to include("can't be blank")
+    end
+
+    it 'is invalid with a duplicate name' do
+      FactoryBot.create(:category, name: 'business')
+      duplicate = FactoryBot.build(:category, name: 'business')
+
+      expect(duplicate).not_to be_valid
+      expect(duplicate.errors[:name]).to include('has already been taken')
+    end
+  end
+end

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -15,15 +15,25 @@ RSpec.describe Category, type: :model do
 
     it 'is invalid without a name' do
       category = FactoryBot.build(:category, name: nil)
-      expect(category).not_to be_valid
+      expect(category).to be_invalid
+    end
+
+    it "adds a can't be blank error when name is missing" do
+      category = FactoryBot.build(:category, name: nil)
+      category.valid?
       expect(category.errors[:name]).to include("can't be blank")
     end
 
     it 'is invalid with a duplicate name' do
       FactoryBot.create(:category, name: 'business')
       duplicate = FactoryBot.build(:category, name: 'business')
+      expect(duplicate).to be_invalid
+    end
 
-      expect(duplicate).not_to be_valid
+    it 'adds a has already been taken error when name is duplicated' do
+      FactoryBot.create(:category, name: 'business')
+      duplicate = FactoryBot.build(:category, name: 'business')
+      duplicate.valid?
       expect(duplicate.errors[:name]).to include('has already been taken')
     end
   end

--- a/spec/models/rephrase_spec.rb
+++ b/spec/models/rephrase_spec.rb
@@ -20,13 +20,23 @@ RSpec.describe Rephrase, type: :model do
 
     it 'is invalid without category' do
       rephrase = FactoryBot.build(:rephrase, category: nil)
-      expect(rephrase).not_to be_valid
+      expect(rephrase).to be_invalid
+    end
+
+    it 'adds a must exist error when category is missing' do
+      rephrase = FactoryBot.build(:rephrase, category: nil)
+      rephrase.valid?
       expect(rephrase.errors[:category]).to include('must exist')
     end
 
     it 'is invalid without content' do
       rephrase = FactoryBot.build(:rephrase, content: nil)
-      expect(rephrase).not_to be_valid
+      expect(rephrase).to be_invalid
+    end
+
+    it "adds a can't be blank error when content is missing" do
+      rephrase = FactoryBot.build(:rephrase, content: nil)
+      rephrase.valid?
       expect(rephrase.errors[:content]).to include("can't be blank")
     end
   end

--- a/spec/models/rephrase_spec.rb
+++ b/spec/models/rephrase_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+RSpec.describe Rephrase, type: :model do
+  describe 'associations' do
+    it 'belongs to category' do
+      association = described_class.reflect_on_association(:category)
+      expect(association.macro).to eq(:belongs_to)
+    end
+
+    it 'has many search_logs' do
+      association = described_class.reflect_on_association(:search_logs)
+      expect(association.macro).to eq(:has_many)
+    end
+  end
+
+  describe 'validations' do
+    it 'is valid with content and category' do
+      expect(FactoryBot.build(:rephrase)).to be_valid
+    end
+
+    it 'is invalid without content' do
+      rephrase = FactoryBot.build(:rephrase, content: nil)
+      expect(rephrase).not_to be_valid
+      expect(rephrase.errors[:content]).to include("can't be blank")
+    end
+  end
+end

--- a/spec/models/rephrase_spec.rb
+++ b/spec/models/rephrase_spec.rb
@@ -18,10 +18,25 @@ RSpec.describe Rephrase, type: :model do
       expect(FactoryBot.build(:rephrase)).to be_valid
     end
 
+    it 'is invalid without category' do
+      rephrase = FactoryBot.build(:rephrase, category: nil)
+      expect(rephrase).not_to be_valid
+      expect(rephrase.errors[:category]).to include('must exist')
+    end
+
     it 'is invalid without content' do
       rephrase = FactoryBot.build(:rephrase, content: nil)
       expect(rephrase).not_to be_valid
       expect(rephrase.errors[:content]).to include("can't be blank")
+    end
+  end
+
+  describe 'dependent destroy' do
+    it 'deletes associated search_logs when rephrase is destroyed' do
+      rephrase = FactoryBot.create(:rephrase)
+      FactoryBot.create(:search_log, rephrase: rephrase)
+
+      expect { rephrase.destroy }.to change(SearchLog, :count).by(-1)
     end
   end
 end

--- a/spec/models/search_log_spec.rb
+++ b/spec/models/search_log_spec.rb
@@ -15,13 +15,23 @@ RSpec.describe SearchLog, type: :model do
 
     it 'is invalid without rephrase' do
       search_log = FactoryBot.build(:search_log, rephrase: nil)
-      expect(search_log).not_to be_valid
+      expect(search_log).to be_invalid
+    end
+
+    it 'adds a must exist error when rephrase is missing' do
+      search_log = FactoryBot.build(:search_log, rephrase: nil)
+      search_log.valid?
       expect(search_log.errors[:rephrase]).to include('must exist')
     end
 
     it 'is invalid without query' do
       search_log = FactoryBot.build(:search_log, query: nil)
-      expect(search_log).not_to be_valid
+      expect(search_log).to be_invalid
+    end
+
+    it "adds a can't be blank error when query is missing" do
+      search_log = FactoryBot.build(:search_log, query: nil)
+      search_log.valid?
       expect(search_log.errors[:query]).to include("can't be blank")
     end
   end

--- a/spec/models/search_log_spec.rb
+++ b/spec/models/search_log_spec.rb
@@ -13,6 +13,12 @@ RSpec.describe SearchLog, type: :model do
       expect(FactoryBot.build(:search_log)).to be_valid
     end
 
+    it 'is invalid without rephrase' do
+      search_log = FactoryBot.build(:search_log, rephrase: nil)
+      expect(search_log).not_to be_valid
+      expect(search_log.errors[:rephrase]).to include('must exist')
+    end
+
     it 'is invalid without query' do
       search_log = FactoryBot.build(:search_log, query: nil)
       expect(search_log).not_to be_valid

--- a/spec/models/search_log_spec.rb
+++ b/spec/models/search_log_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.describe SearchLog, type: :model do
+  describe 'associations' do
+    it 'belongs to rephrase' do
+      association = described_class.reflect_on_association(:rephrase)
+      expect(association.macro).to eq(:belongs_to)
+    end
+  end
+
+  describe 'validations' do
+    it 'is valid with query and rephrase' do
+      expect(FactoryBot.build(:search_log)).to be_valid
+    end
+
+    it 'is invalid without query' do
+      search_log = FactoryBot.build(:search_log, query: nil)
+      expect(search_log).not_to be_valid
+      expect(search_log.errors[:query]).to include("can't be blank")
+    end
+  end
+end


### PR DESCRIPTION
## 概要
アプリケーションの核となる、カテゴリ・言い換え・検索ログの3つのテーブル構築と、それらのモデル実装を完了しました。

## 変更内容
- **DB設計**: 
  - `categories`, `rephrases`, `search_logs` テーブルを作成
  - 各カラムに `null: false` 制約、`categories.name` に一意性制約を適用
  - 外部キー制約をDBレベルで定義
- **モデル実装**:
  - `has_many` / `belongs_to` の関連付けを定義
  - 親データ削除時の連鎖削除（`dependent: :destroy`）を実装
  - 各項目の存在性（presence）および一意性（uniqueness）バリデーションを追加
- **テスト**:
  - RSpec / FactoryBot によるモデルテストを完備（正常系・異常系・連鎖削除の挙動確認）

## 確認事項
- [x] `bin/rails db:migrate` が正常に実行されること
- [x] `db/schema.rb` に意図通りの制約が反映されていること
- [x] 実装済みの全 Model Spec がパスすること

## 備考
PostgreSQLの外部キー制約の依存関係を考慮し、マイグレーションの実行順序を調整済みです。