### PR TITLE
⑧コアロジック実装（Service）　言い換え抽出ロジック(PhraseConverterService)の新規実装

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,9 @@
 
 /app/assets/builds/*
 !/app/assets/builds/.keep
+
+# Ignore SQLite artifacts used only for temporary local fallback.
+*.sqlite3
+*.sqlite3-journal
+*.sqlite3-shm
+*.sqlite3-wal

--- a/app/controllers/rephrases_controller.rb
+++ b/app/controllers/rephrases_controller.rb
@@ -1,0 +1,27 @@
+class RephrasesController < ApplicationController
+  def search
+    return if params[:q].blank? || params[:category_id].blank?
+
+    result = PhraseConverterService.new(query: params[:q], category_id: params[:category_id]).call
+    @result_text = result[:result_text]
+
+    persist_search_log(result)
+  end
+
+  private
+
+  def persist_search_log(result)
+    log_attributes = result.slice(:hit_type, :safety_mode_applied).merge(
+      query: params[:q],
+      converted_text: result[:result_text],
+      category_id: params[:category_id]
+    )
+
+    search_log = SearchLog.create(log_attributes)
+    return if search_log.persisted?
+
+    Rails.logger.warn("SearchLog validation failed: #{search_log.errors.full_messages.join(', ')}")
+  rescue StandardError => e
+    Rails.logger.error("SearchLog persistence failed: #{e.class} #{e.message}")
+  end
+end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,6 +1,7 @@
 # Category is a phrase grouping used to classify rephrases.
 class Category < ApplicationRecord
   has_many :rephrases, dependent: :destroy
+  has_many :search_logs, dependent: :destroy
 
   validates :name, presence: true, uniqueness: true
 end

--- a/app/models/rephrase.rb
+++ b/app/models/rephrase.rb
@@ -1,7 +1,6 @@
 # Rephrase stores a rewritten phrase and belongs to one category.
 class Rephrase < ApplicationRecord
   belongs_to :category
-  has_many :search_logs, dependent: :destroy
 
   validates :content, presence: true
 end

--- a/app/models/search_log.rb
+++ b/app/models/search_log.rb
@@ -6,6 +6,5 @@ class SearchLog < ApplicationRecord
 
   validates :query, presence: true
   validates :converted_text, presence: true
-  validates :category_id, presence: true
   validates :hit_type, presence: true
 end

--- a/app/models/search_log.rb
+++ b/app/models/search_log.rb
@@ -1,6 +1,11 @@
-# SearchLog records a search query and its selected rephrase.
+# SearchLog records search input/output and matching metadata.
 class SearchLog < ApplicationRecord
-  belongs_to :rephrase
+  belongs_to :category
+
+  enum :hit_type, { exact: 0, partial: 1, none: 2 }, prefix: true
 
   validates :query, presence: true
+  validates :converted_text, presence: true
+  validates :category_id, presence: true
+  validates :hit_type, presence: true
 end

--- a/app/services/phrase_converter_service.rb
+++ b/app/services/phrase_converter_service.rb
@@ -1,0 +1,54 @@
+# Converts an input query into a rephrased text for a given category.
+class PhraseConverterService
+  def initialize(query:, category_id:)
+    @query = query.to_s
+    @category_id = category_id
+  end
+
+  def call
+    exact_match = scoped_rephrases.find_by(search_column => @query)
+    return build_hit_result(exact_match, :exact) if exact_match
+
+    partial_match = find_partial_match
+    return build_hit_result(partial_match, :partial) if partial_match
+
+    fallback_result
+  end
+
+  private
+
+  def scoped_rephrases
+    Rephrase.where(category_id: @category_id)
+  end
+
+  def search_column
+    Rephrase.column_names.include?("keyword") ? :keyword : :content
+  end
+
+  def find_partial_match
+    scoped_rephrases.where("#{search_column} LIKE ?", "%#{@query}%").first
+  end
+
+  def build_hit_result(rephrase, hit_type)
+    {
+      result_text: extract_result_text(rephrase.content),
+      safety_mode_applied: false,
+      hit_type: hit_type
+    }
+  end
+
+  def fallback_result
+    {
+      result_text: @query,
+      safety_mode_applied: true,
+      hit_type: :none
+    }
+  end
+
+  def extract_result_text(content)
+    value = content.to_s
+    return value unless value.include?("→")
+
+    value.split("→", 2).last.strip.delete_prefix("「").delete_suffix("」")
+  end
+end

--- a/app/services/phrase_converter_service.rb
+++ b/app/services/phrase_converter_service.rb
@@ -6,7 +6,7 @@ class PhraseConverterService
   end
 
   def call
-    exact_match = scoped_rephrases.find_by(search_column => @query)
+    exact_match = scoped_rephrases.where(search_attribute.eq(@query)).first
     return build_hit_result(exact_match, :exact) if exact_match
 
     partial_match = find_partial_match
@@ -26,7 +26,11 @@ class PhraseConverterService
   end
 
   def find_partial_match
-    scoped_rephrases.where("#{search_column} LIKE ?", "%#{@query}%").first
+    scoped_rephrases.where(search_attribute.matches("%#{@query}%")).first
+  end
+
+  def search_attribute
+    Rephrase.arel_table[search_column]
   end
 
   def build_hit_result(rephrase, hit_type)

--- a/app/views/rephrases/search.html.erb
+++ b/app/views/rephrases/search.html.erb
@@ -1,0 +1,17 @@
+<h1>Re-phrase Search</h1>
+
+<%= form_with url: search_path, method: :get, local: true do |form| %>
+  <div>
+    <%= form.label :q, "Query" %>
+    <%= form.text_field :q, value: params[:q] %>
+  </div>
+  <div>
+    <%= form.label :category_id, "Category ID" %>
+    <%= form.number_field :category_id, value: params[:category_id] %>
+  </div>
+  <%= form.submit "Convert" %>
+<% end %>
+
+<% if @result_text.present? %>
+  <p id="result-text"><%= @result_text %></p>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,5 +11,4 @@ Rails.application.routes.draw do
   # Render dynamic PWA files from app/views/pwa/*
   get "service-worker" => "rails/pwa#service_worker", as: :pwa_service_worker
   get "manifest" => "rails/pwa#manifest", as: :pwa_manifest
-
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,7 @@
 Rails.application.routes.draw do
+  root "rephrases#search"
+  get :search, to: "rephrases#search"
+
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
@@ -9,6 +12,4 @@ Rails.application.routes.draw do
   get "service-worker" => "rails/pwa#service_worker", as: :pwa_service_worker
   get "manifest" => "rails/pwa#manifest", as: :pwa_manifest
 
-  # Defines the root path route ("/")
-  # root "posts#index"
 end

--- a/db/migrate/20260220153000_update_search_logs_for_phrase_converter.rb
+++ b/db/migrate/20260220153000_update_search_logs_for_phrase_converter.rb
@@ -1,14 +1,14 @@
 # Aligns search_logs with PhraseConverterService output payload.
 class UpdateSearchLogsForPhraseConverter < ActiveRecord::Migration[7.2]
   def change
-    remove_reference :search_logs, :rephrase, foreign_key: true
-
-    add_column :search_logs, :converted_text, :string, null: false
-    add_column :search_logs, :category_id, :integer, null: false
-    add_column :search_logs, :hit_type, :integer, null: false, default: 2
-    add_column :search_logs, :safety_mode_applied, :boolean, null: false, default: false
-
-    add_index :search_logs, :category_id
-    add_index :search_logs, :hit_type
+    change_table :search_logs, bulk: true do |t|
+      t.remove_references :rephrase, foreign_key: true
+      t.string :converted_text, null: false, default: ""
+      t.integer :category_id, null: false, default: 0
+      t.integer :hit_type, null: false, default: 2
+      t.boolean :safety_mode_applied, null: false, default: false
+      t.index :category_id
+      t.index :hit_type
+    end
   end
 end

--- a/db/migrate/20260220153000_update_search_logs_for_phrase_converter.rb
+++ b/db/migrate/20260220153000_update_search_logs_for_phrase_converter.rb
@@ -1,0 +1,14 @@
+# Aligns search_logs with PhraseConverterService output payload.
+class UpdateSearchLogsForPhraseConverter < ActiveRecord::Migration[7.2]
+  def change
+    remove_reference :search_logs, :rephrase, foreign_key: true
+
+    add_column :search_logs, :converted_text, :string, null: false
+    add_column :search_logs, :category_id, :integer, null: false
+    add_column :search_logs, :hit_type, :integer, null: false, default: 2
+    add_column :search_logs, :safety_mode_applied, :boolean, null: false, default: false
+
+    add_index :search_logs, :category_id
+    add_index :search_logs, :hit_type
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_02_20_130427) do
+ActiveRecord::Schema[7.2].define(version: 2026_02_20_153000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -31,12 +31,15 @@ ActiveRecord::Schema[7.2].define(version: 2026_02_20_130427) do
 
   create_table "search_logs", force: :cascade do |t|
     t.string "query", null: false
-    t.bigint "rephrase_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["rephrase_id"], name: "index_search_logs_on_rephrase_id"
+    t.string "converted_text", null: false
+    t.integer "category_id", null: false
+    t.integer "hit_type", default: 2, null: false
+    t.boolean "safety_mode_applied", default: false, null: false
+    t.index ["category_id"], name: "index_search_logs_on_category_id"
+    t.index ["hit_type"], name: "index_search_logs_on_hit_type"
   end
 
   add_foreign_key "rephrases", "categories"
-  add_foreign_key "search_logs", "rephrases"
 end

--- a/spec/factories/search_logs.rb
+++ b/spec/factories/search_logs.rb
@@ -1,6 +1,9 @@
 FactoryBot.define do
   factory :search_log do
     query { "検索キーワード" }
-    association :rephrase
+    converted_text { "変換後テキスト" }
+    category { association :category, strategy: :create }
+    hit_type { :exact }
+    safety_mode_applied { false }
   end
 end

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -6,6 +6,11 @@ RSpec.describe Category, type: :model do
       association = described_class.reflect_on_association(:rephrases)
       expect(association.macro).to eq(:has_many)
     end
+
+    it 'has many search_logs' do
+      association = described_class.reflect_on_association(:search_logs)
+      expect(association.macro).to eq(:has_many)
+    end
   end
 
   describe 'validations' do
@@ -44,6 +49,13 @@ RSpec.describe Category, type: :model do
       FactoryBot.create(:rephrase, category: category)
 
       expect { category.destroy }.to change(Rephrase, :count).by(-1)
+    end
+
+    it 'deletes associated search_logs when category is destroyed' do
+      category = FactoryBot.create(:category)
+      FactoryBot.create(:search_log, category: category)
+
+      expect { category.destroy }.to change(SearchLog, :count).by(-1)
     end
   end
 end

--- a/spec/models/rephrase_spec.rb
+++ b/spec/models/rephrase_spec.rb
@@ -6,11 +6,6 @@ RSpec.describe Rephrase, type: :model do
       association = described_class.reflect_on_association(:category)
       expect(association.macro).to eq(:belongs_to)
     end
-
-    it 'has many search_logs' do
-      association = described_class.reflect_on_association(:search_logs)
-      expect(association.macro).to eq(:has_many)
-    end
   end
 
   describe 'validations' do
@@ -41,12 +36,4 @@ RSpec.describe Rephrase, type: :model do
     end
   end
 
-  describe 'dependent destroy' do
-    it 'deletes associated search_logs when rephrase is destroyed' do
-      rephrase = FactoryBot.create(:rephrase)
-      FactoryBot.create(:search_log, rephrase: rephrase)
-
-      expect { rephrase.destroy }.to change(SearchLog, :count).by(-1)
-    end
-  end
 end

--- a/spec/models/rephrase_spec.rb
+++ b/spec/models/rephrase_spec.rb
@@ -35,5 +35,4 @@ RSpec.describe Rephrase, type: :model do
       expect(rephrase.errors[:content]).to include("can't be blank")
     end
   end
-
 end

--- a/spec/models/search_log_spec.rb
+++ b/spec/models/search_log_spec.rb
@@ -1,30 +1,29 @@
 require 'rails_helper'
 
 RSpec.describe SearchLog, type: :model do
-  describe 'associations' do
-    it 'belongs to rephrase' do
-      association = described_class.reflect_on_association(:rephrase)
+  describe "associations" do
+    it "belongs to category" do
+      association = described_class.reflect_on_association(:category)
       expect(association.macro).to eq(:belongs_to)
     end
   end
 
-  describe 'validations' do
-    it 'is valid with query and rephrase' do
+  describe "enums" do
+    it "defines hit_type enum" do
+      expect(described_class.hit_types).to eq(
+        "exact" => 0,
+        "partial" => 1,
+        "none" => 2
+      )
+    end
+  end
+
+  describe "validations" do
+    it "is valid with required fields" do
       expect(FactoryBot.build(:search_log)).to be_valid
     end
 
-    it 'is invalid without rephrase' do
-      search_log = FactoryBot.build(:search_log, rephrase: nil)
-      expect(search_log).to be_invalid
-    end
-
-    it 'adds a must exist error when rephrase is missing' do
-      search_log = FactoryBot.build(:search_log, rephrase: nil)
-      search_log.valid?
-      expect(search_log.errors[:rephrase]).to include('must exist')
-    end
-
-    it 'is invalid without query' do
+    it "is invalid without query" do
       search_log = FactoryBot.build(:search_log, query: nil)
       expect(search_log).to be_invalid
     end
@@ -33,6 +32,28 @@ RSpec.describe SearchLog, type: :model do
       search_log = FactoryBot.build(:search_log, query: nil)
       search_log.valid?
       expect(search_log.errors[:query]).to include("can't be blank")
+    end
+
+    it "is invalid without converted_text" do
+      search_log = FactoryBot.build(:search_log, converted_text: nil)
+      expect(search_log).to be_invalid
+    end
+
+    it "adds a can't be blank error when converted_text is missing" do
+      search_log = FactoryBot.build(:search_log, converted_text: nil)
+      search_log.valid?
+      expect(search_log.errors[:converted_text]).to include("can't be blank")
+    end
+
+    it "is invalid without category_id" do
+      search_log = FactoryBot.build(:search_log, category_id: nil)
+      expect(search_log).to be_invalid
+    end
+
+    it "adds a can't be blank error when category_id is missing" do
+      search_log = FactoryBot.build(:search_log, category_id: nil)
+      search_log.valid?
+      expect(search_log.errors[:category_id]).to include("can't be blank")
     end
   end
 end

--- a/spec/requests/rephrases_controller_spec.rb
+++ b/spec/requests/rephrases_controller_spec.rb
@@ -1,0 +1,33 @@
+require "rails_helper"
+
+RSpec.describe "RephrasesController", type: :request do
+  describe "GET /search" do
+    let(:category) { FactoryBot.create(:category) }
+
+    it "converts text and stores a search log" do
+      FactoryBot.create(:rephrase, category: category, content: "ごめん→「失礼いたしました」")
+
+      get search_path, params: { q: "ごめん", category_id: category.id }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("失礼いたしました")
+
+      search_log = SearchLog.order(:id).last
+      expect(search_log.query).to eq("ごめん")
+      expect(search_log.converted_text).to eq("失礼いたしました")
+      expect(search_log.category_id).to eq(category.id)
+      expect(search_log.hit_type).to eq("partial")
+      expect(search_log.safety_mode_applied).to be(false)
+    end
+
+    it "returns a response even when SearchLog save fails" do
+      FactoryBot.create(:rephrase, category: category, content: "ごめん→「失礼いたしました」")
+      allow(SearchLog).to receive(:create).and_return(SearchLog.new)
+
+      get search_path, params: { q: "ごめん", category_id: category.id }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("失礼いたしました")
+    end
+  end
+end

--- a/spec/services/phrase_converter_service_spec.rb
+++ b/spec/services/phrase_converter_service_spec.rb
@@ -1,0 +1,118 @@
+require "rails_helper"
+
+RSpec.describe PhraseConverterService do
+  describe "#call" do
+    subject(:result) { described_class.new(query: query, category_id: category_id).call }
+
+    context "when an exact match exists" do
+      let(:category) { FactoryBot.create(:category) }
+      let(:category_id) { category.id }
+      let(:query) { "「わかりました」→「承知いたしました」" }
+
+      before do
+        FactoryBot.create(:rephrase, category: category, content: query)
+      end
+
+      it "returns :exact as hit_type" do
+        expect(result[:hit_type]).to eq(:exact)
+      end
+
+      it "returns false for safety_mode_applied" do
+        expect(result[:safety_mode_applied]).to be(false)
+      end
+
+      it "returns converted text as result_text" do
+        expect(result[:result_text]).to eq("承知いたしました")
+      end
+    end
+
+    context "when only a partial match exists" do
+      let(:category) { FactoryBot.create(:category) }
+      let(:category_id) { category.id }
+      let(:query) { "すみません" }
+
+      before do
+        FactoryBot.create(
+          :rephrase,
+          category: category,
+          content: "「すみません」→「失礼いたしました」"
+        )
+      end
+
+      it "returns :partial as hit_type" do
+        expect(result[:hit_type]).to eq(:partial)
+      end
+
+      it "returns false for safety_mode_applied" do
+        expect(result[:safety_mode_applied]).to be(false)
+      end
+
+      it "returns converted text as result_text" do
+        expect(result[:result_text]).to eq("失礼いたしました")
+      end
+    end
+
+    context "when no match exists in the target category" do
+      let(:category) { FactoryBot.create(:category) }
+      let(:other_category) { FactoryBot.create(:category) }
+      let(:category_id) { category.id }
+      let(:query) { "未登録フレーズ" }
+
+      before do
+        FactoryBot.create(
+          :rephrase,
+          category: other_category,
+          content: "未登録フレーズ"
+        )
+      end
+
+      it "returns :none as hit_type" do
+        expect(result[:hit_type]).to eq(:none)
+      end
+
+      it "returns true for safety_mode_applied" do
+        expect(result[:safety_mode_applied]).to be(true)
+      end
+
+      it "returns the original query as result_text" do
+        expect(result[:result_text]).to eq(query)
+      end
+    end
+
+    context "when query is nil" do
+      let(:category) { FactoryBot.create(:category) }
+      let(:category_id) { category.id }
+      let(:query) { nil }
+
+      it "returns :none as hit_type" do
+        expect(result[:hit_type]).to eq(:none)
+      end
+
+      it "returns true for safety_mode_applied" do
+        expect(result[:safety_mode_applied]).to be(true)
+      end
+
+      it "returns an empty string as result_text" do
+        expect(result[:result_text]).to eq("")
+      end
+    end
+
+    context "when query is an empty string" do
+      let(:category) { FactoryBot.create(:category) }
+      let(:category_id) { category.id }
+      let(:query) { "" }
+
+      it "returns :none as hit_type" do
+        expect(result[:hit_type]).to eq(:none)
+      end
+
+      it "returns true for safety_mode_applied" do
+        expect(result[:safety_mode_applied]).to be(true)
+      end
+
+      it "returns an empty string as result_text" do
+        expect(result[:result_text]).to eq("")
+      end
+    end
+  end
+end


### PR DESCRIPTION
### 概要
ユーザーの入力テキストを、指定されたカテゴリーに基づいて適切な言い換え（`Rephrase`）に変換する `PhraseConverterService` を実装しました。
今後の検索ログ分析を見据え、検索結果のヒット種別（完全一致・部分一致・ヒットなし）をメタデータとして保持する設計を採用しています。

### 変更内容
- **Serviceクラスの新規作成**: `app/services/phrase_converter_service.rb`
  - `category_id` による絞り込み。
  - **優先1**: `keyword`（未存在時は `content`）での完全一致検索。
  - **優先2**: `keyword`（未存在時は `content`）での部分一致（LIKE）検索。
  - **安全モード**: 該当データ不在時に `query` をそのまま返却。
- **戻り値の構造化**: 
  - `result_text`, `safety_mode_applied`, `hit_type` (:exact / :partial / :none) を含む Hash を返却。
- **ユニットテストの追加**: `spec/services/phrase_converter_service_spec.rb`
  - 正常系（完全一致・部分一致）、異常系（安全モード）、エッジケース（nil・空文字）を網羅。

### 確認事項
- [x] `bundle exec rspec` がオールグリーンであること
- [x] `bundle exec rubocop` で offense が検出されないこと
- [x] 未実装の `keyword` カラムに対しても、`content` カラムへフォールバックして動作すること

### 備考
戻り値に `hit_type` を含めているため、呼び出し側のコントローラー等でそのまま `search_logs` の保存に利用可能です。