### PR TITLE
言い換え画面の新規構築とHotwireによる非同期変換の実装

### DIFF
--- a/app/controllers/rephrases_controller.rb
+++ b/app/controllers/rephrases_controller.rb
@@ -5,8 +5,49 @@ class RephrasesController < ApplicationController
     @search_logs = SearchLog.order(created_at: :desc).limit(10)
   end
 
-  # create実装前の仮ハンドラ
+  # 言い換え処理を実行し、結果と履歴をTurbo Streamで更新
   def create
-    head :ok
+    @search_log = build_search_log
+    respond_with_rephrase
+  end
+
+  private
+
+  # フォームから受け取る言い換え入力値
+  def rephrase_params
+    params.require(:rephrase).permit(:content, :scene, :target, :context)
+  end
+
+  # sceneをカテゴリとして扱い、存在しなければ作成してIDを返す
+  def resolved_category_id
+    scene = rephrase_params[:scene].to_s.strip
+    return Category.first_or_create!(name: "default").id if scene.blank?
+
+    if scene.match?(/\A\d+\z/) && Category.exists?(scene.to_i)
+      scene.to_i
+    else
+      Category.find_or_create_by!(name: scene).id
+    end
+  end
+
+  # 言い換え結果をもとにSearchLogを作成
+  def build_search_log
+    category_id = resolved_category_id
+    result = PhraseConverterService.call(query: rephrase_params[:content], category_id: category_id)
+
+    SearchLog.create!(
+      query: rephrase_params[:content],
+      converted_text: result[:result_text],
+      category_id: category_id,
+      **result.slice(:hit_type, :safety_mode_applied)
+    )
+  end
+
+  # Turbo Stream と通常HTMLのレスポンスを切り替え
+  def respond_with_rephrase
+    respond_to do |format|
+      format.turbo_stream
+      format.html { redirect_to rephrases_path }
+    end
   end
 end

--- a/app/controllers/rephrases_controller.rb
+++ b/app/controllers/rephrases_controller.rb
@@ -1,29 +1,12 @@
-# Handles search requests and persists conversion metadata.
+# 言い換え画面の表示と作成処理の入口を提供するコントローラー
 class RephrasesController < ApplicationController
-  def search
-    return if params[:q].blank? || params[:category_id].blank?
-
-    result = PhraseConverterService.new(query: params[:q], category_id: params[:category_id]).call
-    assign_result_values(result)
-    save_search_log(result)
+  # 直近の検索履歴を表示する初期画面
+  def index
+    @search_logs = SearchLog.order(created_at: :desc).limit(10)
   end
 
-  private
-
-  def assign_result_values(result)
-    @result_text = result[:result_text]
-    @safety_mode_applied = result[:safety_mode_applied]
-    @hit_type = result[:hit_type]
-  end
-
-  def save_search_log(result)
-    SearchLog.create!(
-      query: params[:q],
-      converted_text: @result_text,
-      category_id: params[:category_id],
-      **result.slice(:hit_type, :safety_mode_applied)
-    )
-  rescue StandardError => e
-    Rails.logger.error("SearchLog persistence failed: #{e.class} #{e.message}")
+  # create実装前の仮ハンドラ
+  def create
+    head :ok
   end
 end

--- a/app/javascript/controllers/clipboard_controller.js
+++ b/app/javascript/controllers/clipboard_controller.js
@@ -1,0 +1,39 @@
+import { Controller } from "@hotwired/stimulus"
+
+// 変換結果のコピー操作と通知表示を扱うコントローラー
+export default class extends Controller {
+  static targets = ["source", "feedback", "button"]
+
+  // 結果テキストをクリップボードへコピーする
+  async copy() {
+    if (!this.hasSourceTarget) return
+
+    const text = this.sourceTarget.textContent.trim()
+    if (text.length === 0) return
+
+    try {
+      await navigator.clipboard.writeText(text)
+      this.showFeedback("コピーしました")
+    } catch (_error) {
+      this.showFeedback("コピーに失敗しました")
+    }
+  }
+
+  // コピー結果を短時間表示し、元の表示へ戻す
+  showFeedback(message) {
+    if (this.hasFeedbackTarget) {
+      this.feedbackTarget.textContent = message
+      this.feedbackTarget.classList.remove("hidden")
+      setTimeout(() => this.feedbackTarget.classList.add("hidden"), 1800)
+    }
+
+    if (this.hasButtonTarget) {
+      const original = this.buttonTarget.dataset.originalLabel || this.buttonTarget.textContent
+      this.buttonTarget.dataset.originalLabel = original
+      this.buttonTarget.textContent = message
+      setTimeout(() => {
+        this.buttonTarget.textContent = original
+      }, 1800)
+    }
+  }
+}

--- a/app/javascript/controllers/rephrase_controller.js
+++ b/app/javascript/controllers/rephrase_controller.js
@@ -1,0 +1,14 @@
+import { Controller } from "@hotwired/stimulus"
+
+// 入力フォームの補助操作（クリア）を扱うコントローラー
+export default class extends Controller {
+  static targets = ["content"]
+
+  // 原文テキストエリアだけをクリアする
+  clearContent() {
+    if (!this.hasContentTarget) return
+
+    this.contentTarget.value = ""
+    this.contentTarget.focus()
+  }
+}

--- a/app/services/phrase_converter_service.rb
+++ b/app/services/phrase_converter_service.rb
@@ -1,5 +1,10 @@
 # Converts an input query into a rephrased text for a given category.
 class PhraseConverterService
+  # 既存の呼び出し口としてクラスメソッドを提供
+  def self.call(query:, category_id:)
+    new(query: query, category_id: category_id).call
+  end
+
   def initialize(query:, category_id:)
     @query = query.to_s
     @category_id = category_id

--- a/app/views/rephrases/_history_item.html.erb
+++ b/app/views/rephrases/_history_item.html.erb
@@ -1,0 +1,4 @@
+<article class="rounded border p-3 text-sm">
+  <p class="font-medium"><%= search_log.query %></p>
+  <p class="text-gray-600"><%= search_log.converted_text %></p>
+</article>

--- a/app/views/rephrases/_result.html.erb
+++ b/app/views/rephrases/_result.html.erb
@@ -1,6 +1,26 @@
 <%= turbo_frame_tag "rephrase_result" do %>
-  <section class="rounded-lg border p-4">
-    <h2 class="text-sm font-semibold text-gray-500">変換結果</h2>
-    <p class="mt-2 text-lg font-medium"><%= @search_log.converted_text %></p>
+  <section class="rounded-xl border bg-white p-5 shadow-sm" data-controller="clipboard">
+    <div class="grid gap-4 md:grid-cols-2">
+      <article class="rounded-lg border bg-gray-50 p-4">
+        <p class="text-xs font-semibold tracking-wide text-gray-500">BEFORE</p>
+        <p class="mt-2 whitespace-pre-wrap text-sm text-gray-800"><%= @search_log.query %></p>
+      </article>
+
+      <article class="rounded-lg border bg-emerald-50 p-4">
+        <div class="flex items-start justify-between gap-3">
+          <p class="text-xs font-semibold tracking-wide text-emerald-700">AFTER</p>
+          <button
+            type="button"
+            class="rounded-lg border border-emerald-300 bg-white px-3 py-1 text-xs font-medium text-emerald-700"
+            data-clipboard-target="button"
+            data-action="clipboard#copy"
+          >
+            コピー
+          </button>
+        </div>
+        <p class="mt-2 whitespace-pre-wrap text-sm font-medium text-gray-900" data-clipboard-target="source"><%= @search_log.converted_text %></p>
+        <p class="mt-2 hidden text-xs font-medium text-emerald-700" data-clipboard-target="feedback">コピーしました</p>
+      </article>
+    </div>
   </section>
 <% end %>

--- a/app/views/rephrases/_result.html.erb
+++ b/app/views/rephrases/_result.html.erb
@@ -1,0 +1,6 @@
+<%= turbo_frame_tag "rephrase_result" do %>
+  <section class="rounded-lg border p-4">
+    <h2 class="text-sm font-semibold text-gray-500">変換結果</h2>
+    <p class="mt-2 text-lg font-medium"><%= @search_log.converted_text %></p>
+  </section>
+<% end %>

--- a/app/views/rephrases/create.turbo_stream.erb
+++ b/app/views/rephrases/create.turbo_stream.erb
@@ -1,0 +1,7 @@
+<%= turbo_stream.replace "rephrase_result" do %>
+  <%= render "rephrases/result" %>
+<% end %>
+
+<%= turbo_stream.prepend "history_list" do %>
+  <%= render "rephrases/history_item", search_log: @search_log %>
+<% end %>

--- a/app/views/rephrases/index.html.erb
+++ b/app/views/rephrases/index.html.erb
@@ -5,15 +5,25 @@
   </header>
 
   <%# 言い換え実行フォーム %>
-  <%= form_with url: rephrases_path, method: :post, class: "space-y-4 rounded-lg border p-4" do |form| %>
+  <%= form_with url: rephrases_path, method: :post, scope: :rephrase, class: "space-y-4 rounded-lg border p-4" do |form| %>
     <div class="space-y-1">
-      <%= form.label :query, "原文", class: "block text-sm font-medium" %>
-      <%= form.text_area :query, rows: 4, class: "w-full rounded border px-3 py-2" %>
+      <%= form.label :content, "原文", class: "block text-sm font-medium" %>
+      <%= form.text_area :content, rows: 4, class: "w-full rounded border px-3 py-2" %>
     </div>
 
-    <div class="space-y-1">
-      <%= form.label :category_id, "カテゴリID", class: "block text-sm font-medium" %>
-      <%= form.number_field :category_id, class: "w-full rounded border px-3 py-2" %>
+    <div class="grid gap-4 md:grid-cols-3">
+      <div class="space-y-1">
+        <%= form.label :scene, "シーン", class: "block text-sm font-medium" %>
+        <%= form.text_field :scene, class: "w-full rounded border px-3 py-2" %>
+      </div>
+      <div class="space-y-1">
+        <%= form.label :target, "相手", class: "block text-sm font-medium" %>
+        <%= form.text_field :target, class: "w-full rounded border px-3 py-2" %>
+      </div>
+      <div class="space-y-1">
+        <%= form.label :context, "状況", class: "block text-sm font-medium" %>
+        <%= form.text_field :context, class: "w-full rounded border px-3 py-2" %>
+      </div>
     </div>
 
     <%= form.submit "言い換える", class: "rounded bg-black px-4 py-2 text-white" %>
@@ -28,7 +38,7 @@
 
   <section class="space-y-3">
     <h2 class="text-lg font-semibold">最近の履歴</h2>
-    <div class="space-y-2">
+    <div id="history_list" class="space-y-2">
       <% @search_logs.each do |search_log| %>
         <%= render "history_item", search_log: search_log %>
       <% end %>

--- a/app/views/rephrases/index.html.erb
+++ b/app/views/rephrases/index.html.erb
@@ -5,10 +5,10 @@
   </header>
 
   <%# 言い換え実行フォーム %>
-  <%= form_with url: rephrases_path, method: :post, scope: :rephrase, class: "space-y-4 rounded-lg border p-4" do |form| %>
+  <%= form_with url: rephrases_path, method: :post, scope: :rephrase, class: "space-y-4 rounded-xl border bg-white p-5 shadow-sm", data: { controller: "rephrase" } do |form| %>
     <div class="space-y-1">
       <%= form.label :content, "原文", class: "block text-sm font-medium" %>
-      <%= form.text_area :content, rows: 4, class: "w-full rounded border px-3 py-2" %>
+      <%= form.text_area :content, rows: 5, class: "w-full rounded-lg border px-3 py-2", data: { rephrase_target: "content" } %>
     </div>
 
     <div class="grid gap-4 md:grid-cols-3">
@@ -26,14 +26,26 @@
       </div>
     </div>
 
-    <%= form.submit "言い換える", class: "rounded bg-black px-4 py-2 text-white" %>
+    <div class="flex items-center gap-3">
+      <%= form.submit "言い換える", class: "rounded-lg bg-black px-4 py-2 text-white" %>
+      <button type="button" class="rounded-lg border px-4 py-2 text-sm" data-action="rephrase#clearContent">クリア</button>
+    </div>
   <% end %>
 
   <%# Turboで差し替える結果表示領域 %>
   <%= turbo_frame_tag "rephrase_result" do %>
-    <div class="rounded-lg border border-dashed p-4 text-sm text-gray-500">
-      ここに言い換え結果が表示されます。
-    </div>
+    <section class="rounded-xl border border-dashed bg-white p-5 text-sm text-gray-500">
+      <div class="grid gap-4 md:grid-cols-2">
+        <article class="rounded-lg border bg-gray-50 p-4">
+          <p class="text-xs font-semibold tracking-wide text-gray-500">BEFORE</p>
+          <p class="mt-2 text-sm">ここに原文が表示されます。</p>
+        </article>
+        <article class="rounded-lg border bg-gray-50 p-4">
+          <p class="text-xs font-semibold tracking-wide text-gray-500">AFTER</p>
+          <p class="mt-2 text-sm">ここに提案結果が表示されます。</p>
+        </article>
+      </div>
+    </section>
   <% end %>
 
   <section class="space-y-3">

--- a/app/views/rephrases/index.html.erb
+++ b/app/views/rephrases/index.html.erb
@@ -1,0 +1,37 @@
+<section class="mx-auto max-w-4xl space-y-8 px-4 py-8">
+  <header class="space-y-2">
+    <h1 class="text-2xl font-bold">文章の言い換え</h1>
+    <p class="text-sm text-gray-600">入力した文章を丁寧な表現に変換します。</p>
+  </header>
+
+  <%# 言い換え実行フォーム %>
+  <%= form_with url: rephrases_path, method: :post, class: "space-y-4 rounded-lg border p-4" do |form| %>
+    <div class="space-y-1">
+      <%= form.label :query, "原文", class: "block text-sm font-medium" %>
+      <%= form.text_area :query, rows: 4, class: "w-full rounded border px-3 py-2" %>
+    </div>
+
+    <div class="space-y-1">
+      <%= form.label :category_id, "カテゴリID", class: "block text-sm font-medium" %>
+      <%= form.number_field :category_id, class: "w-full rounded border px-3 py-2" %>
+    </div>
+
+    <%= form.submit "言い換える", class: "rounded bg-black px-4 py-2 text-white" %>
+  <% end %>
+
+  <%# Turboで差し替える結果表示領域 %>
+  <%= turbo_frame_tag "rephrase_result" do %>
+    <div class="rounded-lg border border-dashed p-4 text-sm text-gray-500">
+      ここに言い換え結果が表示されます。
+    </div>
+  <% end %>
+
+  <section class="space-y-3">
+    <h2 class="text-lg font-semibold">最近の履歴</h2>
+    <div class="space-y-2">
+      <% @search_logs.each do |search_log| %>
+        <%= render "history_item", search_log: search_log %>
+      <% end %>
+    </div>
+  </section>
+</section>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 Rails.application.routes.draw do
-  root "rephrases#search"
-  get :search, to: "rephrases#search"
+  # 言い換え機能の最小構成（一覧表示 + 作成）
+  resources :rephrases, only: %i[index create]
+  root "rephrases#index"
 
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 


### PR DESCRIPTION
## 概要
「言い換え機能」のベースUIを構築し、Hotwire (Turbo/Stimulus) を活用してリロードなしで結果表示と履歴更新ができるように実装しました。

## 実施したこと
- 言い換え画面のベースUI構築（Tailwind CSS使用）
- `RephrasesController` の作成とルーティング設定
- `PhraseConverterService` を用いた変換ロジックの実装
- Turbo Stream を使用した非同期更新（結果表示および履歴リストへの追加）
- Stimulus による「入力クリア」および「クリップボードコピー」機能の追加

## 確認方法
1. `http://localhost:3000/rephrases` にアクセス
2. テキストエリアに文章を入力し、シーンや相手を選択して「言い換え」を実行
3. 画面がリロードされずに「変換結果」が表示され、下の「履歴リスト」に項目が増えることを確認
4. 「コピー」ボタンで結果がクリップボードに保存されることを確認
5. 「クリア」ボタンで入力内容が消えることを確認

## 備考
- コミットメッセージおよびコード内コメントは日本語で統一しています。
- RuboCopにて静的解析済みです。