### PR TITLE
【履歴管理】3案の個別表示とLocalStorage保存ロジックの実装

### DIFF
--- a/app/javascript/controllers/history_controller.js
+++ b/app/javascript/controllers/history_controller.js
@@ -1,0 +1,86 @@
+import { Controller } from "@hotwired/stimulus"
+
+const STORAGE_KEY = "rephrase_history"
+const MAX_HISTORY_ITEMS = 30
+
+export default class extends Controller {
+  connect() {
+    this.observer = new MutationObserver((mutations) => {
+      this.handleMutations(mutations)
+    })
+
+    this.observer.observe(this.element, {
+      childList: true,
+      subtree: true
+    })
+  }
+
+  disconnect() {
+    if (this.observer) {
+      this.observer.disconnect()
+      this.observer = null
+    }
+  }
+
+  handleMutations(mutations) {
+    mutations.forEach((mutation) => {
+      mutation.addedNodes.forEach((node) => {
+        if (!(node instanceof Element)) return
+
+        this.extractHistoryItems(node).forEach((item) => {
+          this.saveHistoryItem(item)
+        })
+      })
+    })
+  }
+
+  extractHistoryItems(node) {
+    const items = []
+
+    if (node.matches(".history-item")) {
+      const data = this.extractTextData(node)
+      if (data) items.push(data)
+    }
+
+    node.querySelectorAll(".history-item").forEach((itemNode) => {
+      const data = this.extractTextData(itemNode)
+      if (data) items.push(data)
+    })
+
+    return items
+  }
+
+  extractTextData(itemNode) {
+    const originalText = itemNode.querySelector(".original-text")?.textContent?.trim() || ""
+    const rephrasedText = itemNode.querySelector(".rephrased-text")?.textContent?.trim() || ""
+
+    if (!originalText || !rephrasedText) return null
+
+    return { originalText, rephrasedText }
+  }
+
+  saveHistoryItem(item) {
+    const history = this.readHistory()
+
+    const isDuplicate = history.some((entry) => {
+      return entry.originalText === item.originalText && entry.rephrasedText === item.rephrasedText
+    })
+    if (isDuplicate) return
+
+    history.unshift(item)
+    const truncated = history.slice(0, MAX_HISTORY_ITEMS)
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(truncated))
+  }
+
+  readHistory() {
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY)
+      if (!raw) return []
+
+      const parsed = JSON.parse(raw)
+      return Array.isArray(parsed) ? parsed : []
+    } catch (_error) {
+      return []
+    }
+  }
+}

--- a/app/models/search_log.rb
+++ b/app/models/search_log.rb
@@ -1,12 +1,37 @@
 # SearchLog records search input/output and matching metadata.
 class SearchLog < ApplicationRecord
+  DEFAULT_CATEGORY_NAME = "default".freeze
+
   belongs_to :category
 
-  # DB接続が不安定な開発環境でも enum の型解決を安定させる
-  attribute :hit_type, :integer
+  # DBカラム未反映/認識遅延時でも enum の型解決を安定させる
+  attribute :hit_type, :integer, default: 2
   enum :hit_type, { exact: 0, partial: 1, none: 2 }, prefix: true
+
+  before_validation :ensure_default_category
+  before_validation :normalize_hit_type
 
   validates :query, presence: true
   validates :converted_text, presence: true
   validates :hit_type, presence: true
+
+  private
+
+  def ensure_default_category
+    return if category.present?
+
+    self.category = Category.find_or_create_by!(name: DEFAULT_CATEGORY_NAME)
+  end
+
+  def normalize_hit_type
+    key = case self[:hit_type]
+          when Integer
+            self.class.hit_types.key(self[:hit_type])
+          else
+            hit_type_before_type_cast.to_s.strip
+          end
+
+    normalized_key = self.class.hit_types.key?(key) ? key : "none"
+    self[:hit_type] = self.class.hit_types.fetch(normalized_key)
+  end
 end

--- a/app/views/rephrases/_form_errors.html.erb
+++ b/app/views/rephrases/_form_errors.html.erb
@@ -1,0 +1,32 @@
+<% has_error_message = error_message.present? %>
+<% has_field_errors = field_errors.present? && field_errors.values.any?(&:present?) %>
+<% field_labels = {
+  content: "入力文",
+  scene: "シーン",
+  target: "相手の関係性",
+  context: "状況",
+  category: "カテゴリ",
+  category_id: "カテゴリ",
+  query: "検索文",
+  converted_text: "言い換え結果",
+  hit_type: "判定種別",
+  rephrase: "言い換え"
+} %>
+
+<% if has_error_message || has_field_errors %>
+  <section class="rounded-xl border border-red-300 bg-red-50 p-4 text-sm text-red-700">
+    <p class="font-semibold">保存に失敗しました</p>
+    <% if has_error_message %>
+      <p class="mt-1"><%= error_message %></p>
+    <% end %>
+    <% if has_field_errors %>
+      <ul class="mt-2 list-disc pl-5 space-y-1">
+        <% field_errors.each do |attribute, messages| %>
+          <% next if messages.blank? %>
+          <% label = field_labels[attribute.to_sym] || attribute.to_s.humanize %>
+          <li><%= "#{label}: #{messages.uniq.join(', ')}" %></li>
+        <% end %>
+      </ul>
+    <% end %>
+  </section>
+<% end %>

--- a/app/views/rephrases/_history_item.html.erb
+++ b/app/views/rephrases/_history_item.html.erb
@@ -1,9 +1,10 @@
-<article class="flex items-center justify-between p-3 bg-white rounded-xl border border-slate-100">
+<article class="history-item flex items-center justify-between p-3 bg-white rounded-xl border border-slate-100">
   <div class="flex-1 min-w-0 pr-4">
     <div class="flex items-center gap-2 mb-1">
       <span class="text-[10px] text-slate-400"><%= time_ago_in_words(search_log.created_at) %>前</span>
     </div>
-    <p class="text-xs text-slate-600 truncate"><%= search_log.query %></p>
+    <p class="original-text text-xs text-slate-600 truncate"><%= search_log.query %></p>
+    <p class="rephrased-text mt-1 text-xs text-slate-500 line-clamp-2"><%= search_log.converted_text %></p>
   </div>
   <div class="flex items-center gap-1 shrink-0">
     <button type="button" class="p-1.5 text-slate-400 hover:text-primary hover:bg-primary/5 rounded-lg transition-all">

--- a/app/views/rephrases/create.turbo_stream.erb
+++ b/app/views/rephrases/create.turbo_stream.erb
@@ -2,6 +2,10 @@
   <%= render partial: "rephrases/rephrase_result", locals: { rephrased_results: @rephrased_results } %>
 <% end %>
 
+<%= turbo_stream.update "form_errors" do %>
+  <%= render "rephrases/form_errors", error_message: @error_message, field_errors: @field_errors %>
+<% end %>
+
 <% if @search_log.present? %>
   <%= turbo_stream.prepend "history_list" do %>
     <%= render "rephrases/history_item", search_log: @search_log %>

--- a/app/views/rephrases/create.turbo_stream.erb
+++ b/app/views/rephrases/create.turbo_stream.erb
@@ -6,8 +6,10 @@
   <%= render "rephrases/form_errors", error_message: @error_message, field_errors: @field_errors %>
 <% end %>
 
-<% if @search_log.present? %>
-  <%= turbo_stream.prepend "history_list" do %>
-    <%= render "rephrases/history_item", search_log: @search_log %>
+<% if @search_logs.present? %>
+  <% @search_logs.reverse_each do |search_log| %>
+    <%= turbo_stream.prepend "history_list" do %>
+      <%= render "rephrases/history_item", search_log: search_log %>
+    <% end %>
   <% end %>
 <% end %>

--- a/app/views/rephrases/error.turbo_stream.erb
+++ b/app/views/rephrases/error.turbo_stream.erb
@@ -6,3 +6,7 @@
     </section>
   <% end %>
 <% end %>
+
+<%= turbo_stream.update "form_errors" do %>
+  <%= render "rephrases/form_errors", error_message: @error_message, field_errors: @field_errors %>
+<% end %>

--- a/app/views/rephrases/index.html.erb
+++ b/app/views/rephrases/index.html.erb
@@ -75,7 +75,7 @@
           <span class="text-[10px] bg-slate-200 text-slate-500 px-2 py-0.5 rounded-full"><%= @search_logs.size %></span>
         </div>
       </summary>
-      <div id="history_list" class="p-4 space-y-3 border-t border-slate-200 max-h-80 overflow-y-auto">
+      <div id="history_list" data-controller="history" class="p-4 space-y-3 border-t border-slate-200 max-h-80 overflow-y-auto">
         <% @search_logs.each do |search_log| %>
           <%= render "history_item", search_log: search_log %>
         <% end %>

--- a/app/views/rephrases/index.html.erb
+++ b/app/views/rephrases/index.html.erb
@@ -10,6 +10,10 @@
 </header>
 
 <main class="max-w-4xl mx-auto p-4 sm:p-6 space-y-6">
+  <div id="form_errors">
+    <%= render "rephrases/form_errors", error_message: @error_message, field_errors: @field_errors %>
+  </div>
+
   <%= form_with url: rephrases_path, method: :post, scope: :rephrase, class: "space-y-6", data: { controller: "rephrase" } do |form| %>
     <section class="bg-white rounded-2xl border border-slate-200 shadow-sm overflow-hidden focus-within:ring-2 focus-within:ring-primary/20 transition-all">
       <div class="p-1 flex justify-end bg-slate-50/50 border-b border-slate-100">

--- a/config/database.yml
+++ b/config/database.yml
@@ -3,7 +3,7 @@ default: &default
   encoding: unicode
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   # 共通フォールバック設定
-  host: <%= ENV.fetch("DB_HOST", "localhost") %>
+  host: <%= ENV.fetch("DB_HOST", "/var/run/postgresql") %>
   port: <%= ENV.fetch("DB_PORT", 5432) %>
   username: <%= ENV.fetch("DB_USERNAME", "vscode") %>
   password: <%= ENV.fetch("DB_PASSWORD", "postgres") %>

--- a/db/migrate/20260221121110_add_converted_text_to_search_logs.rb
+++ b/db/migrate/20260221121110_add_converted_text_to_search_logs.rb
@@ -1,0 +1,5 @@
+class AddConvertedTextToSearchLogs < ActiveRecord::Migration[7.2]
+  def change
+    add_column :search_logs, :converted_text, :text
+  end
+end

--- a/db/migrate/20260221121110_add_converted_text_to_search_logs.rb
+++ b/db/migrate/20260221121110_add_converted_text_to_search_logs.rb
@@ -1,3 +1,4 @@
+# Adds converted text column to search logs.
 class AddConvertedTextToSearchLogs < ActiveRecord::Migration[7.2]
   def change
     add_column :search_logs, :converted_text, :text

--- a/db/migrate/20260221121110_add_converted_text_to_search_logs.rb
+++ b/db/migrate/20260221121110_add_converted_text_to_search_logs.rb
@@ -1,6 +1,8 @@
 # Adds converted text column to search logs.
 class AddConvertedTextToSearchLogs < ActiveRecord::Migration[7.2]
   def change
+    return if column_exists?(:search_logs, :converted_text)
+
     add_column :search_logs, :converted_text, :text
   end
 end


### PR DESCRIPTION
## 概要
言い換え実行時に、AIが生成した3つの提案を個別のカードとして表示し、それらを自動的にブラウザのLocalStorageに保存する機能を実装しました。

## 実装内容
1. **生成ロジックの改善**
   - 1回の実行で[短文][標準][フォーマル]の3パターンを生成するようプロンプトを強化。
   - `temperature` を調整し、毎回異なる語彙で生成されるよう多様化。
2. **バックエンド（Rails）の修正**
   - AIの回答（1. 2. 3.）を分割し、3つの独立した `SearchLog` レコードとして保存。
   - Turbo Streamを用いて、3つのカードを非同期で履歴リストの先頭に追加。
3. **フロントエンド（Stimulus）の実装**
   - `history_controller.js` を新規作成。
   - `MutationObserver` を使用し、リストへの追加を検知して `rephrase_history` キーで保存。
   - 重複排除ロジックと最大30件の保持制限を追加。

## 動作確認結果
- 言い換え実行後、即座に3枚の独立したカードが履歴に追加されることを確認。
- デベロッパーツールの Application > Local Storage にて、3件のデータがJSON形式で保存されていることを確認。