### PR TITLE
【履歴管理】LocalStorageからの履歴復元（ハイドレーション）と再分割表示の実装

### DIFF
--- a/app/javascript/controllers/history_controller.js
+++ b/app/javascript/controllers/history_controller.js
@@ -5,11 +5,14 @@ const MAX_HISTORY_ITEMS = 30
 
 export default class extends Controller {
   connect() {
+    this.hydrateFromStorage()
+    this.trimRenderedItems()
+
     this.observer = new MutationObserver((mutations) => {
       this.handleMutations(mutations)
     })
 
-    this.observer.observe(this.element, {
+    this.observer.observe(this.listElement, {
       childList: true,
       subtree: true
     })
@@ -32,6 +35,8 @@ export default class extends Controller {
         })
       })
     })
+
+    this.trimRenderedItems()
   }
 
   extractHistoryItems(node) {
@@ -82,5 +87,97 @@ export default class extends Controller {
     } catch (_error) {
       return []
     }
+  }
+
+  hydrateFromStorage() {
+    const history = this.readHistory()
+    if (history.length === 0) return
+
+    const existingRephrased = new Set(this.currentRephrasedTexts())
+
+    history.forEach((item) => {
+      if (!item || typeof item !== "object") return
+      if (!item.originalText || !item.rephrasedText) return
+
+      this.expandStoredRephrasedTexts(item.rephrasedText).forEach((rephrasedText) => {
+        if (existingRephrased.has(rephrasedText)) return
+
+        this.listElement.appendChild(this.buildHistoryItemElement({
+          originalText: item.originalText,
+          rephrasedText: rephrasedText
+        }))
+        existingRephrased.add(rephrasedText)
+      })
+    })
+  }
+
+  expandStoredRephrasedTexts(rephrasedText) {
+    const text = (rephrasedText || "").trim()
+    if (!text) return []
+
+    if (!/^\s*\d+[.)]?\s+/.test(text)) return [text]
+
+    return text.split(/\n?\s*\d+[.)]?\s*/).map((item) => item.trim()).filter((item) => item.length > 0)
+  }
+
+  currentRephrasedTexts() {
+    return Array.from(this.listElement.querySelectorAll(".rephrased-text")).map((node) => {
+      return node.textContent?.trim() || ""
+    }).filter((text) => text.length > 0)
+  }
+
+  buildHistoryItemElement(item) {
+    const article = document.createElement("article")
+    article.className = "history-item flex items-center justify-between p-3 bg-white rounded-xl border border-slate-100"
+
+    const body = document.createElement("div")
+    body.className = "flex-1 min-w-0 pr-4"
+
+    const meta = document.createElement("div")
+    meta.className = "flex items-center gap-2 mb-1"
+    const metaText = document.createElement("span")
+    metaText.className = "text-[10px] text-slate-400"
+    metaText.textContent = "保存済み"
+    meta.appendChild(metaText)
+
+    const original = document.createElement("p")
+    original.className = "original-text text-xs text-slate-600 truncate"
+    original.textContent = item.originalText
+
+    const rephrased = document.createElement("p")
+    rephrased.className = "rephrased-text mt-1 text-xs text-slate-500 line-clamp-2"
+    rephrased.textContent = item.rephrasedText
+
+    body.appendChild(meta)
+    body.appendChild(original)
+    body.appendChild(rephrased)
+
+    const actions = document.createElement("div")
+    actions.className = "flex items-center gap-1 shrink-0"
+    const button = document.createElement("button")
+    button.type = "button"
+    button.className = "p-1.5 text-slate-400 hover:text-primary hover:bg-primary/5 rounded-lg transition-all"
+    const icon = document.createElement("span")
+    icon.className = "material-icons text-sm"
+    icon.textContent = "content_copy"
+    button.appendChild(icon)
+    actions.appendChild(button)
+
+    article.appendChild(body)
+    article.appendChild(actions)
+    return article
+  }
+
+  trimRenderedItems() {
+    const items = Array.from(this.listElement.querySelectorAll(".history-item"))
+    if (items.length <= MAX_HISTORY_ITEMS) return
+
+    items.slice(MAX_HISTORY_ITEMS).forEach((node) => node.remove())
+  }
+
+  get listElement() {
+    if (this.element.id === "history_list") return this.element
+
+    return this.element.querySelector("#history_list") || this.element
   }
 }


### PR DESCRIPTION
## 概要
ページ読み込み時に LocalStorage から過去の言い換え履歴を読み込み、サーバー側のデータと合わせて最大30件まで表示する機能を実装しました。また、保存データが1つの塊になっている場合に、JS側で動的に再分割してカード化する仕組みを導入しました。

## 実装内容
1. **履歴の復元（ハイドレーション）**
   - `history_controller.js` の `connect()` 時に LocalStorage からデータを取得し、画面に再描画するロジックを実装。
2. **表示の個別カード化と再分割**
   - LocalStorage 内のデータが「1. 2. 3.」形式の単一文字列であっても、JS側の正規表現で分割し、独立したカードとして描画する `expandStoredRephrasedTexts` を実装。
3. **重複排除と件数制限**
   - サーバーから出力済みのテキストとの重複をチェックし、二重表示を防止。
   - 画面上の表示件数が30件を超えた場合、古いものから順にDOMから削除するトリミング機能を実装。
4. **MutationObserver の最適化**
   - リスト要素の監視を安定化させ、動的な追加と30件制限の維持を両立。

## 動作確認結果
- ページをリロードした際、LocalStorage に保存された過去分が正しく復元されることを確認。
- 1つの枠に固まっていた履歴が、リロード後に3つの独立したカードに分解されて表示されることを確認。
- 30件を超えた際に、古い履歴から順に消去されることを確認。