### PR TITLE
CIでRSpec・RuboCop・Brakemanの自動品質チェックを整備

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,10 +3,13 @@ name: CI
 on:
   pull_request:
   push:
-    branches: [ main ]
+    branches: ["**"]
+
+env:
+  BUNDLE_WITH: development:test
 
 jobs:
-  scan_ruby:
+  brakeman:
     runs-on: ubuntu-latest
 
     steps:
@@ -19,26 +22,10 @@ jobs:
           ruby-version: .ruby-version
           bundler-cache: true
 
-      - name: Scan for common Rails security vulnerabilities using static analysis
-        run: bin/brakeman --no-pager
+      - name: Run Brakeman
+        run: bundle exec brakeman --no-pager
 
-  scan_js:
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: .ruby-version
-          bundler-cache: true
-
-      - name: Scan for security vulnerabilities in JavaScript dependencies
-        run: bin/importmap audit
-
-  lint:
+  rubocop:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -50,32 +37,34 @@ jobs:
           ruby-version: .ruby-version
           bundler-cache: true
 
-      - name: Lint code for consistent style
-        run: bin/rubocop -f github
+      - name: Run RuboCop
+        run: bundle exec rubocop -f github
 
-  test:
+  rspec:
     runs-on: ubuntu-latest
+    env:
+      RAILS_ENV: test
+      DB_HOST: localhost
+      DB_PORT: 5432
+      DB_USERNAME: postgres
+      DB_PASSWORD: postgres
+      DB_NAME_TEST: re_phrase_test
 
     services:
       postgres:
-        image: postgres
+        image: postgres:16
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
         ports:
           - 5432:5432
-        options: --health-cmd="pg_isready" --health-interval=10s --health-timeout=5s --health-retries=3
-
-      # redis:
-      #   image: redis
-      #   ports:
-      #     - 6379:6379
-      #   options: --health-cmd "redis-cli ping" --health-interval 10s --health-timeout 5s --health-retries 5
+        options: >-
+          --health-cmd="pg_isready -U postgres -d postgres"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=10
 
     steps:
-      - name: Install packages
-        run: sudo apt-get update && sudo apt-get install --no-install-recommends -y google-chrome-stable curl libjemalloc2 libvips postgresql-client
-
       - name: Checkout code
         uses: actions/checkout@v4
 
@@ -86,25 +75,7 @@ jobs:
           bundler-cache: true
 
       - name: Set up test database
-        env:
-          RAILS_ENV: test
-          DATABASE_URL: postgres://postgres:postgres@localhost:5432/re_phrase_test
-          # REDIS_URL: redis://localhost:6379/0
-        run: |
-          bin/rails db:prepare
-          bin/rails db:schema:dump
+        run: bin/rails db:prepare
 
-      - name: Run tests
-        env:
-          RAILS_ENV: test
-          DATABASE_URL: postgres://postgres:postgres@localhost:5432/re_phrase_test
-          # REDIS_URL: redis://localhost:6379/0
-        run: bin/rails test test:system
-
-      - name: Keep screenshots from failed system tests
-        uses: actions/upload-artifact@v4
-        if: failure()
-        with:
-          name: screenshots
-          path: ${{ github.workspace }}/tmp/screenshots
-          if-no-files-found: ignore
+      - name: Run RSpec
+        run: bundle exec rspec

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,5 +77,8 @@ jobs:
       - name: Set up test database
         run: bin/rails db:prepare
 
+      - name: Build Tailwind CSS
+        run: bin/rails tailwindcss:build
+
       - name: Run RSpec
         run: bundle exec rspec


### PR DESCRIPTION
## 概要
GitHub Actions の CI を整理し、push / pull_request 時に品質チェックが自動実行されるようにしました。

## 変更内容
- `.github/workflows/ci.yml` を更新
- CIジョブを以下の3つに整理
  - Brakeman: `bundle exec brakeman --no-pager`
  - RuboCop: `bundle exec rubocop -f github`
  - RSpec: `bundle exec rspec`
- `push`（全ブランチ）および `pull_request` で起動
- RSpecジョブのDB設定を明示
  - `RAILS_ENV=test`
  - `DB_HOST=localhost`
  - `DB_PORT=5432`
  - `DB_USERNAME=postgres`
  - `DB_PASSWORD=postgres`
  - `DB_NAME_TEST=re_phrase_test`
- PostgreSQL service の安定化
  - `postgres:16` に固定
  - health check を強化（retries=10）
- Bundlerグループを明示
  - `BUNDLE_WITH=development:test`

## 確認結果（ローカル）
- `bundle exec rspec` : ✅（46 examples, 0 failures）
- `bundle exec rubocop -f github` : ✅
- `bundle exec brakeman --no-pager` : ✅（Security Warnings: 0）

## 補足
- 以前の `bin/brakeman` は `--ensure-latest` によりCIで不安定要因となるため、CIでは `bundle exec brakeman` を使用しています。
